### PR TITLE
fix toascii 0x for PtrToString

### DIFF
--- a/framework/util/to_string.h
+++ b/framework/util/to_string.h
@@ -65,11 +65,18 @@ inline std::string ToString(uint32_t      apiFlags,
 }
 
 template <typename PtrType>
+inline std::string PtrToString(PtrType* ptr)
+{
+    std::stringstream strStrm;
+    strStrm << "0x" << std::hex << reinterpret_cast<uintptr_t>(ptr);
+    return strStrm.str();
+}
+
+template <typename PtrType>
 inline std::string PtrToString(PtrType ptr)
 {
     std::stringstream strStrm;
-    const void*       val = reinterpret_cast<const void*>(ptr);
-    strStrm << "0x" << std::hex << reinterpret_cast<uint64_t>(val);
+    strStrm << "0x" << std::hex << ptr;
     return strStrm.str();
 }
 


### PR DESCRIPTION
just print "ptr" for non-pointer types

for pointer types, print "ptr" cast to uintptr_t